### PR TITLE
Version 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,22 @@ You have several ways to install this SDK
 
     git clone https://github.com/ansible-dellemc-unity/dellemc-unity-sdk.git
     cd dellemc-unity-sdk
-    python setup.py sdist
-    sudo pip install dist/<archive that ends with version>
+    python setup.py sdist bdist_wheel
+    sudo pip install dist/dellemc_unity_sdk.xxxx.tar.gz
 
 ## How to write modules?
 
-According to our experience and [issue #4](https://github.com/ansible-dellemc-unity/dellemc-unity-sdk/issues/4) , you should create an instance of AnsibleModule in your module
-own module, so to create argument_spec use:
+According to our experience and [issue #4](https://github.com/ansible-dellemc-unity/dellemc-unity-sdk/issues/4) , 
+you should create an instance of AnsibleModule in your module. So to create you should argument_spec use:
 
 ``supportive_functions.create_arguments_for_ansible_module(array_of_dictionaries)`` or 
 ``supportive_functions.create_arguments_for_ansible_module(template)``
 
-After that make an instance of AnsibleModule and put it with template into
+After that make an instance of AnsibleModule and put it next to template into
 
 ``runner.run(ansible_module, template)``
 
-Your module will be automatically execute by SDK.
+Your module will be automatically executed by SDK.
 
 ## How to write templates for runner.run(...)
 

--- a/dellemc_unity_sdk/constants.py
+++ b/dellemc_unity_sdk/constants.py
@@ -1,14 +1,19 @@
 #!/usr/bin/python
 from enum import Enum
 
-EXECUTED_BY_KEY = "executed_by"
+EXECUTED_BY_KEY = "executed_by"  # TODO: remove later
+EXECUTED_BY = "executed_by"
 EXECUTED_BY_SDK = "executed_by_sdk"
 ACTION_TYPE_KEY = "action_type"
 PARAMETER_TYPES_KEY = "parameter_types"
-REST_OBJECT_KEY = "rest_object"
-ACTIONS_KEY = "actions"
+REST_OBJECT_KEY = "rest_object"  # TODO: remove later
+REST_OBJECT = "rest_object"
+ACTIONS_KEY = "actions"  # TODO: remove later
+ACTIONS = "actions"
 ACTION_NAME = "function"
 DO_ACTION = "do_action"
+GET = "get"
+REST_OBJECT_FOR_GET_REQUEST = "rest_object_for_get"
 
 
 class ActionType(Enum):

--- a/dellemc_unity_sdk/runner.py
+++ b/dellemc_unity_sdk/runner.py
@@ -91,8 +91,9 @@ def run(ansible_module, template):
                                                                                      "constants.ActionType")
                 executing_module_info.update({action_name: info})
         if params.get('get'):
-            info = do_query_request(unity, params.get('get'), {}, rest_object)
-            executing_module_info.update({'get': info})
+            if not ('get' in actions.keys()):
+                info = do_query_request(unity, params.get('get'), {}, rest_object)
+                executing_module_info.update({'get': info})
 
     except Exception as err:
         ansible_module.fail_json(changed=unity.changed, msg=err.__str__(),

--- a/dellemc_unity_sdk/unity.py
+++ b/dellemc_unity_sdk/unity.py
@@ -1,10 +1,9 @@
 #!/usr/bin/python
+import requests, json, re
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'students'}
-
-import requests, json, re
 
 __author__ = "Andrew Petrov"
 __email__ = "marsofandrew@gmail.com"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
+# with open("README.md", "r") as fh:
+#    long_description = fh.read()
 
 setup(
     name="dellemc_unity_sdk",
@@ -10,10 +10,11 @@ setup(
     author="Dmitry Mityushin",
     author_email="mityushin.dmitry@gmail.com",
     description="Package used to create requests to DellEMC Unity.",
-    long_description=long_description,
+    # long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ansible-dellemc-unity/dellemc-unity-sdk",
     install_requires=find_packages(),
+    # install_requires=['requests', 'ansible']
     classifiers=(
         "Programming Language :: Python",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
-#with open("README.md", "r") as fh:
-#    long_description = fh.read()
+with open("README.md", "r") as fh:
+    long_description = fh.read()
 
 setup(
     name="dellemc_unity_sdk",
@@ -10,7 +10,7 @@ setup(
     author="Dmitry Mityushin",
     author_email="mityushin.dmitry@gmail.com",
     description="Package used to create requests to DellEMC Unity.",
-    #long_description=long_description,
+    long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ansible-dellemc-unity/dellemc-unity-sdk",
     install_requires=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-# with open("README.md", "r") as fh:
+#with open("README.md", "r") as fh:
 #    long_description = fh.read()
 
 setup(
@@ -10,11 +10,10 @@ setup(
     author="Dmitry Mityushin",
     author_email="mityushin.dmitry@gmail.com",
     description="Package used to create requests to DellEMC Unity.",
-    # long_description=long_description,
+    #long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ansible-dellemc-unity/dellemc-unity-sdk",
     install_requires=find_packages(),
-    # install_requires=['requests', 'ansible']
     classifiers=(
         "Programming Language :: Python",
         "License :: OSI Approved :: MIT License",

--- a/test/test_supportive_functions.py
+++ b/test/test_supportive_functions.py
@@ -60,6 +60,32 @@ class TestRunner(unittest.TestCase):
             expected_args.update({action: dict(required=False, default=None, type='dict')})
         self.assertEqual(arguments, expected_args, {'expected_args': expected_args})
 
+    def test_create_arguments_for_ansible_module_define_get(self):
+        template = {
+            constants.REST_OBJECT_KEY: 'fileInterface',
+            constants.ACTIONS_KEY: {
+                'create':
+                    {constants.ACTION_TYPE_KEY: constants.ActionType.UPDATE,
+                     constants.PARAMETER_TYPES_KEY: {}},
+                'modify':
+                    {constants.ACTION_TYPE_KEY: constants.ActionType.UPDATE,
+                     constants.PARAMETER_TYPES_KEY: {}},
+                'delete':
+                    {constants.ACTION_TYPE_KEY: constants.ActionType.UPDATE,
+                     constants.PARAMETER_TYPES_KEY: {}},
+                'get':{
+                    constants.ACTION_TYPE_KEY: constants.ActionType.QUERY,
+                    constants.PARAMETER_TYPES_KEY:{}
+                }
+            }
+        }
+        arguments = supportive_functions.create_arguments_for_ansible_module(template)
+        expected_args = dict(login=dict(required=True, default=None, type='dict'),
+                             get=dict(required=False, default=None, type='dict'))
+        for action in {'create', 'modify', 'delete'}:
+            expected_args.update({action: dict(required=False, default=None, type='dict')})
+        self.assertEqual(arguments, expected_args, {'expected_args': expected_args})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_supportive_functions.py
+++ b/test/test_supportive_functions.py
@@ -66,7 +66,8 @@ class TestRunner(unittest.TestCase):
             constants.ACTIONS_KEY: {
                 'create':
                     {constants.ACTION_TYPE_KEY: constants.ActionType.UPDATE,
-                     constants.PARAMETER_TYPES_KEY: {}},
+                     constants.PARAMETER_TYPES_KEY: {},
+                     constants.DO_ACTION: 'nnnn'},
                 'modify':
                     {constants.ACTION_TYPE_KEY: constants.ActionType.UPDATE,
                      constants.PARAMETER_TYPES_KEY: {}},


### PR DESCRIPTION
add new features:
add new keys for making request, you can use constants.REST_OBJECT_FOR_GET_REQUEST to redefine rest_object for all get requests, and you also can redefine REST object for any action if you add key: constants.REST_OBJECT or constants.REST_OBJECT_KEY